### PR TITLE
Add feature optionally read from GPG file

### DIFF
--- a/bin/dynect4r-client
+++ b/bin/dynect4r-client
@@ -5,6 +5,7 @@ require 'optparse'
 require 'pp'
 require 'set'
 require 'etc'
+require 'gpgme'
 
 # set default command line options
 options = {
@@ -76,11 +77,17 @@ RestClient.log = log
 
 # validate command line options
 begin
-  (options[:customer_name], options[:user_name], options[:password]) = File.open(options[:cred_file]).readline().strip().split()
-rescue Errno::ENOENT
-  log.error('Credentials file does not exist: %s' % options[:cred_file])
-  Process.exit(8)
+  # Try GPG
+  (options[:customer_name], options[:user_name], options[:password]) = GPGME::Crypto.decrypt(File.open(options[:cred_file]).read()).read().split()
+rescue
+  begin
+    (options[:customer_name], options[:user_name], options[:password]) = File.open(options[:cred_file]).readline().strip().split()
+  rescue Errno::ENOENT
+    log.error('Credentials file does not exist: %s' % options[:cred_file])
+    Process.exit(8)
+  end
 end
+
 if !options[:zone]
   options[:zone] = options[:node][(options[:node].index('.') + 1)..-1]
 end

--- a/dynect4r.gemspec
+++ b/dynect4r.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('json')
   s.add_dependency('rest-client')
+  s.add_dependency('gpgme')
 
   s.files = ['LICENSE', 'README.rdoc'] + Dir['lib/*.rb'] + Dir['bin/*.rb']
   s.executables = ['dynect4r-client']


### PR DESCRIPTION
This adds a feature to optionally try reading from a GPG encrypted file,
using the GPGME gem. If the file is not GPG encrypted, it will fall
back to the legacy behaviour.